### PR TITLE
ServerFiles: Allow server url without slash

### DIFF
--- a/serverfiles/__init__.py
+++ b/serverfiles/__init__.py
@@ -256,8 +256,7 @@ class ServerFiles:
         self._download_server_info()
         files = self.listfiles(*path, recursive=recursive)
         infos = {}
-        for a in files:
-            npath = a
+        for npath in files:
             infos[npath] = self.info(*npath)
         return infos
 

--- a/serverfiles/__init__.py
+++ b/serverfiles/__init__.py
@@ -158,7 +158,10 @@ class ServerFiles:
     """A class for listing or downloading files from the server."""
 
     def __init__(self, server, username=None, password=None):
-        self.server = server
+        if server.endswith('/'):
+            self.server = server
+        else:
+            self.server = server + '/'
         """Server URL."""
         self.username = username
         """Username for authenticated HTTP queried."""
@@ -288,7 +291,8 @@ class ServerFiles:
         auth = None
         if self.username and self.password:
             auth = (self.username, self.password)
-        return self.req.get(root+"/".join(path), auth=auth, verify=False, timeout=TIMEOUT, stream=True)
+        return self.req.get(root + "/".join(path), auth=auth, verify=False,
+                            timeout=TIMEOUT, stream=True)
 
     def _open(self, *args):
         return self._server_request(self.server, *args)


### PR DESCRIPTION
Currently it was assumed the user gives a server url with a trailing slash (`/`) otherwise strange things start happening.
Append it if it is not there instead.