### PR TITLE
[ENH] Handle resource warnings, add testing with Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        python: [3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Run tests
+        run: python -m unittest --verbose tests

--- a/serverfiles/__init__.py
+++ b/serverfiles/__init__.py
@@ -290,8 +290,14 @@ class ServerFiles:
         auth = None
         if self.username and self.password:
             auth = (self.username, self.password)
-        return requests.get(root + "/".join(path), auth=auth,
-                            timeout=TIMEOUT, stream=True)
+
+        adapter = requests.adapters.HTTPAdapter(max_retries=3)
+        session = requests.Session()
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+
+        return session.get(root + "/".join(path), auth=auth,
+                           timeout=TIMEOUT, stream=True)
 
     def _open(self, *args) -> requests.Response:
         return self._server_request(self.server, *args)


### PR DESCRIPTION
Fixes warnings when running tests :
```
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/shutil.py:410: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  entries = list(scandir_it)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/shutil.py:410: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  entries = list(scandir_it)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:386: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/qs/jt34t5mx4cb_7ph1_10z6f_w0000gn/T/tmpm03hp10t/comp/gz'>
  shutil.copyfileobj(f, open(target, "wb"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/client.py:267: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/client.py:267: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:372: ResourceWarning: unclosed file <_io.BufferedRandom name=6>
  callback=callback)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:389: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/qs/jt34t5mx4cb_7ph1_10z6f_w0000gn/T/tmpm03hp10t/comp/bz2'>
  shutil.copyfileobj(f, open(target, "wb"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:297: ResourceWarning: unclosed file <_io.FileIO name=7 mode='rb+' closefd=True>
  b".".join([_idna_encode(label) for label in host.split(".")])
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:297: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  b".".join([_idna_encode(label) for label in host.split(".")])
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:297: ResourceWarning: unclosed file <_io.FileIO name=9 mode='rb+' closefd=True>
  b".".join([_idna_encode(label) for label in host.split(".")])
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/json/encoder.py:256: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  self.skipkeys, _one_shot)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/json/encoder.py:256: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  self.skipkeys, _one_shot)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/json/encoder.py:256: ResourceWarning: unclosed <socket.socket [closed] fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  self.skipkeys, _one_shot)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/json/encoder.py:256: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  self.skipkeys, _one_shot)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/structures.py:60: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  return (casedkey for casedkey, mappedvalue in self._store.values())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/structures.py:60: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  return (casedkey for casedkey, mappedvalue in self._store.values())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/connectionpool.py:387: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  conn.request(method, url, **httplib_request_kw)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/connectionpool.py:387: ResourceWarning: unclosed <socket.socket [closed] fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  conn.request(method, url, **httplib_request_kw)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/connectionpool.py:387: ResourceWarning: unclosed <socket.socket [closed] fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  conn.request(method, url, **httplib_request_kw)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
../Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed <socket.socket [closed] fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed <socket.socket [closed] fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed file <_io.FileIO name=12 mode='rb+' closefd=True>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/adapters.py:164: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  block=block, strict=True, **pool_kwargs)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:303: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  if name and any([ord(x) > 128 for x in name]):
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:303: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  if name and any([ord(x) > 128 for x in name]):
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:303: ResourceWarning: unclosed <socket.socket [closed] fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  if name and any([ord(x) > 128 for x in name]):
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/util/url.py:303: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  if name and any([ord(x) > 128 for x in name]):
ResourceWarning: Enable tracemalloc to get the object allocation traceback
../Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:511: ResourceWarning: unclosed <socket.socket [closed] fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6>
  params=params or {},
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:511: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  params=params or {},
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:511: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  params=params or {},
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:386: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/qs/jt34t5mx4cb_7ph1_10z6f_w0000gn/T/tmpfxrk209c/comp/gz'>
  shutil.copyfileobj(f, open(target, "wb"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:389: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/qs/jt34t5mx4cb_7ph1_10z6f_w0000gn/T/tmpfxrk209c/comp/bz2'>
  shutil.copyfileobj(f, open(target, "wb"))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
../Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/request.py:42: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  self.headers = headers or {}
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/request.py:42: ResourceWarning: unclosed file <_io.FileIO name=9 mode='rb+' closefd=True>
  self.headers = headers or {}
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/request.py:42: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  self.headers = headers or {}
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/request.py:42: ResourceWarning: unclosed file <_io.FileIO name=11 mode='rb+' closefd=True>
  self.headers = headers or {}
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/urllib3/request.py:42: ResourceWarning: unclosed file <_io.FileIO name=12 mode='rb+' closefd=True>
  self.headers = headers or {}
ResourceWarning: Enable tracemalloc to get the object allocation traceback
.../Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:415: ResourceWarning: unclosed file <_io.FileIO name=8 mode='rb+' closefd=True>
  self.mount('http://', HTTPAdapter())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:415: ResourceWarning: unclosed file <_io.FileIO name=9 mode='rb+' closefd=True>
  self.mount('http://', HTTPAdapter())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/orange/lib/python3.7/site-packages/requests/sessions.py:415: ResourceWarning: unclosed file <_io.FileIO name=10 mode='rb+' closefd=True>
  self.mount('http://', HTTPAdapter())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed file <_io.FileIO name=9 mode='rb+' closefd=True>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/.pyenv/versions/3.7.6/lib/python3.7/http/cookiejar.py:1217: ResourceWarning: unclosed file <_io.FileIO name=11 mode='rb+' closefd=True>
  keys = sorted(adict.keys())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/jakakokosar/Documents/dev/serverfiles/serverfiles/__init__.py:372: ResourceWarning: unclosed file <_io.BufferedRandom name=8>
  callback=callback)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
.
----------------------------------------------------------------------
Ran 16 tests in 2.653s

```