### PR TITLE
test_serverfiles: Add a short sleep after terminate

### DIFF
--- a/tests/test_serverfiles.py
+++ b/tests/test_serverfiles.py
@@ -82,6 +82,7 @@ class TestServerFiles(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.http.terminate()
+        time.sleep(0.1)
         shutil.rmtree(cls.pathserver)
 
     def setUp(self):


### PR DESCRIPTION
Check if sleeping helps.
The tests sometimes failed on windows with:
```
ERROR: tearDownClass (tests.test_serverfiles.TestServerFiles)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\serverfiles\serverfiles\tests\test_serverfiles.py", line 85, in tearDownClass
    shutil.rmtree(cls.pathserver)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\shutil.py", line 740, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\shutil.py", line 622, in _rmtree_unsafe
    onerror(os.rmdir, path, sys.exc_info())
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\shutil.py", line 620, in _rmtree_unsafe
    os.rmdir(path)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmplvrx9nsj'
```